### PR TITLE
feat(KRY-379): let admin server list buckets in aws

### DIFF
--- a/aws/admin-server/iam.tf
+++ b/aws/admin-server/iam.tf
@@ -172,6 +172,13 @@ data "aws_iam_policy_document" "deploy" {
   }
 
   statement {
+    sid       = "ListAllBuckets"
+    effect    = "Allow"
+    actions   = ["s3:ListAllMyBuckets"]
+    resources = ["*"]
+  }
+
+  statement {
     sid    = "EKS"
     effect = "Allow"
     actions = [


### PR DESCRIPTION
Give admin server in aws permissions to list all buckets in the account its running in. This permission is [already available](https://github.com/project-n-oss/project-n-setup/blob/master/gcp/iam.tf#L22) in gcp. Per [docs](https://cloud.google.com/storage/docs/access-control/iam-permissions) admin server already allowed to list all buckets in the project.