### PR TITLE
Only use specified identity when SSHing onto AWS admin server

### DIFF
--- a/aws/outputs.tf
+++ b/aws/outputs.tf
@@ -5,12 +5,12 @@ locals {
 }
 
 output "ssh_command" {
-  value       = "ssh -i ssh_key.pem ec2-user@${local.instance_url}"
+  value       = "ssh -o IdentitiesOnly=yes -i ssh_key.pem ec2-user@${local.instance_url}"
   description = "The command to ssh into the admin server"
 }
 
 output "scp_command" {
-  value = "scp -q -i ssh_key.pem %s ec2-user@${local.instance_url}:~"
+  value       = "scp -q -i ssh_key.pem %s ec2-user@${local.instance_url}:~"
   description = "The command to copy a file into the admin server"
 }
 


### PR DESCRIPTION
Per title, only use the specified identity when SSHing into the AWS admin server to avoid immediate "too many authentication failures" from the admin server SSH agent if too many keys loaded locally.

https://serverfault.com/questions/989678/locked-out-of-my-own-server-getting-too-many-authentication-failures-right-aw

sample error logs from the above scenario when running setup

```bash
Received disconnect from 18.213.115.129 port 22:2: Too many authentication failures
Disconnected from 18.213.115.129 port 22
Waiting for login permissions to propagate...
Received disconnect from 18.213.115.129 port 22:2: Too many authentication failures
Disconnected from 18.213.115.129 port 22
Waiting for login permissions to propagate...
Received disconnect from 18.213.115.129 port 22:2: Too many authentication failures
Disconnected from 18.213.115.129 port 22
Waiting for login permissions to propagate...
Received disconnect from 18.213.115.129 port 22:2: Too many authentication failures
Disconnected from 18.213.115.129 port 22
Waiting for login permissions to propagate...
Received disconnect from 18.213.115.129 port 22:2: Too many authentication failures
Disconnected from 18.213.115.129 port 22
Waiting for login permissions to propagate...
Received disconnect from 18.213.115.129 port 22:2: Too many authentication failures
Disconnected from 18.213.115.129 port 22
Waiting for login permissions to propagate...
Received disconnect from 18.213.115.129 port 22:2: Too many authentication failures
Disconnected from 18.213.115.129 port 22
Waiting for login permissions to propagate...
Received disconnect from 18.213.115.129 port 22:2: Too many authentication failures
Disconnected from 18.213.115.129 port 22
Waiting for login permissions to propagate...
```