### PR TITLE
chore: Don't run explicit yum update on GCP admin server

### DIFF
--- a/gcp/admin_server.tf
+++ b/gcp/admin_server.tf
@@ -1,8 +1,8 @@
 resource "random_id" "admin_name_suffix" {
   keepers = {
     # Generate a new id if anything is changed which will create a new admin server
-    project = local.project
-    zone = local.zone
+    project      = local.project
+    zone         = local.zone
     machine_type = var.admin_server_instance_type
   }
   byte_length = 3
@@ -24,7 +24,6 @@ chown -R ${local.ssh_username} /home/${local.ssh_username} 2>> $log
 echo $(ls -la /home/${local.ssh_username}) >> $log
 echo $(ls -la /home/${local.ssh_username}/.project-n) >> $log
 echo '{"default_platform":"gcp"}' > /home/${local.ssh_username}/.project-n/config 2>> $log
-sudo yum -y update
 sudo yum -y install ${var.package_url} 2>> $log
 sudo yum -y install google-cloud-sdk-gke-gcloud-auth-plugin 2>> $log
   EOF


### PR DESCRIPTION
Per title, do not run an explicit `yum update` in the GCP admin server startup script. It takes a long time to complete (on the order of 10-15 minutes) to the point where it feels stuck looping at `Waiting for the Project N package to finish installing...`.

Generally `yum update` is recommended to update all installed packages (things like security patches being a concern here), however `yum install` will update the package being installed and install/update all dependencies to the latest version while it runs.

This will speed up the time to provision a new GCP admin server.