### PR TITLE
feat: add eks addon mgmt perms to admin server deploy iam policy

### DIFF
--- a/aws/admin-server/iam.tf
+++ b/aws/admin-server/iam.tf
@@ -188,7 +188,12 @@ data "aws_iam_policy_document" "deploy" {
       "eks:UpdateClusterVersion",
       "eks:AssociateEncryptionConfig",
       "eks:TagResource",
-      "eks:UntagResource"
+      "eks:UntagResource",
+      "eks:CreateAddon",
+      "eks:DeleteAddon",
+      "eks:DescribeAddon",
+      "eks:DescribeAddonVersions",
+      "eks:ListAddons"
     ]
     resources = [
       "arn:aws:eks:*:*:cluster/project-n-*"


### PR DESCRIPTION
These permissions are required to manage EKS addons for things like EBS CSI Driver (needed post EKS 1.22)