### PR TITLE
fix: gcloud cli install

### DIFF
--- a/gcp/admin_server.tf
+++ b/gcp/admin_server.tf
@@ -35,8 +35,8 @@ gpgcheck=1
 repo_gpgcheck=0
 gpgkey=https://packages.cloud.google.com/yum/doc/rpm-package-key.gpg
 EOM
-sudo dnf install -y google-cloud-cli
-sudo fnd install -y google-cloud-cli-gke-gcloud-auth-plugin
+sudo dnf install -y google-cloud-cli 2>> $log
+sudo dnf install -y google-cloud-cli-gke-gcloud-auth-plugin 2>> $log
 # sudo yum -y install google-cloud-sdk-gke-gcloud-auth-plugin 2>> $log
   EOF
   # labels, metadata, resource_policies, and tags are all set automatically, and may cause the server to be recreated.

--- a/gcp/admin_server.tf
+++ b/gcp/admin_server.tf
@@ -25,7 +25,7 @@ echo $(ls -la /home/${local.ssh_username}) >> $log
 echo $(ls -la /home/${local.ssh_username}/.project-n) >> $log
 echo '{"default_platform":"gcp"}' > /home/${local.ssh_username}/.project-n/config 2>> $log
 sudo yum -y update
-# sudo yum -y install ${var.package_url} 2>> $log
+sudo yum -y install ${var.package_url} 2>> $log
 sudo tee -a /etc/yum.repos.d/google-cloud-sdk.repo << EOM
 [google-cloud-cli]
 name=Google Cloud CLI
@@ -37,7 +37,6 @@ gpgkey=https://packages.cloud.google.com/yum/doc/rpm-package-key.gpg
 EOM
 sudo dnf install -y google-cloud-cli 2>> $log
 sudo dnf install -y google-cloud-cli-gke-gcloud-auth-plugin 2>> $log
-# sudo yum -y install google-cloud-sdk-gke-gcloud-auth-plugin 2>> $log
   EOF
   # labels, metadata, resource_policies, and tags are all set automatically, and may cause the server to be recreated.
   labels            = {}

--- a/gcp/admin_server.tf
+++ b/gcp/admin_server.tf
@@ -1,8 +1,8 @@
 resource "random_id" "admin_name_suffix" {
   keepers = {
     # Generate a new id if anything is changed which will create a new admin server
-    project = local.project
-    zone = local.zone
+    project      = local.project
+    zone         = local.zone
     machine_type = var.admin_server_instance_type
   }
   byte_length = 3
@@ -25,8 +25,19 @@ echo $(ls -la /home/${local.ssh_username}) >> $log
 echo $(ls -la /home/${local.ssh_username}/.project-n) >> $log
 echo '{"default_platform":"gcp"}' > /home/${local.ssh_username}/.project-n/config 2>> $log
 sudo yum -y update
-sudo yum -y install ${var.package_url} 2>> $log
-sudo yum -y install google-cloud-sdk-gke-gcloud-auth-plugin 2>> $log
+# sudo yum -y install ${var.package_url} 2>> $log
+sudo tee -a /etc/yum.repos.d/google-cloud-sdk.repo << EOM
+[google-cloud-cli]
+name=Google Cloud CLI
+baseurl=https://packages.cloud.google.com/yum/repos/cloud-sdk-el9-x86_64
+enabled=1
+gpgcheck=1
+repo_gpgcheck=0
+gpgkey=https://packages.cloud.google.com/yum/doc/rpm-package-key.gpg
+EOM
+sudo dnf install -y google-cloud-cli
+sudo fnd install -y google-cloud-cli-gke-gcloud-auth-plugin
+# sudo yum -y install google-cloud-sdk-gke-gcloud-auth-plugin 2>> $log
   EOF
   # labels, metadata, resource_policies, and tags are all set automatically, and may cause the server to be recreated.
   labels            = {}


### PR DESCRIPTION
Installing via vanilla `yum install` was breaking gke auth plugin instlal and hampered further install activities that relied on interacting with the GKE cluster.

This changes follow the official cli install guide: https://cloud.google.com/sdk/docs/install-sdk#rpm