### PR TITLE
feat: support for dual-region Crunch

### DIFF
--- a/aws/admin-server/iam.tf
+++ b/aws/admin-server/iam.tf
@@ -318,7 +318,8 @@ data "aws_iam_policy_document" "vpc" {
       "ec2:DeleteTags",
       // VPC Peering
       "ec2:CreateVpcPeeringConnection",
-      "ec2:DeleteVpcPeeringConnection"
+      "ec2:DeleteVpcPeeringConnection",
+      "ec2:AcceptVpcPeeringConnection",
     ]
     resources = ["*"]
   }

--- a/aws/admin-server/install_server.tf
+++ b/aws/admin-server/install_server.tf
@@ -65,7 +65,7 @@ resource "aws_instance" "admin" {
   ami                         = data.aws_ami.amazon-linux-2.id
   associate_public_ip_address = true
   iam_instance_profile        = aws_iam_instance_profile.admin.name
-  instance_type               = "t2.small"
+  instance_type               = "t2.micro"
   key_name                    = local.ssh_key_name
   security_groups             = var.subnet_id == null ? [aws_security_group.ssh.name] : null
   vpc_security_group_ids      = var.subnet_id != null ? [aws_security_group.ssh.id] : null

--- a/aws/admin-server/install_server.tf
+++ b/aws/admin-server/install_server.tf
@@ -65,7 +65,7 @@ resource "aws_instance" "admin" {
   ami                         = data.aws_ami.amazon-linux-2.id
   associate_public_ip_address = true
   iam_instance_profile        = aws_iam_instance_profile.admin.name
-  instance_type               = "t2.micro"
+  instance_type               = "t2.small"
   key_name                    = local.ssh_key_name
   security_groups             = var.subnet_id == null ? [aws_security_group.ssh.name] : null
   vpc_security_group_ids      = var.subnet_id != null ? [aws_security_group.ssh.id] : null

--- a/aws/admin-server/install_server.tf
+++ b/aws/admin-server/install_server.tf
@@ -81,6 +81,9 @@ resource "aws_instance" "admin" {
 #!/bin/bash
 yum -y update
 yum -y install ${var.package_url}
+sudo git clone https://github.com/ahmetb/kubectx /opt/kubectx
+sudo ln -s /opt/kubectx/kubectx /usr/local/bin/kubectx
+sudo ln -s /opt/kubectx/kubens /usr/local/bin/kubens
 su ec2-user -c 'pip3 install awscli==1.27.20 awscli-plugin-granica --user'
 echo 'export PATH=~/.local/bin:$PATH' >> /home/ec2-user/.bash_profile && chown ec2-user /home/ec2-user/.bash_profile
 su ec2-user -c 'source ~/.bash_profile && aws configure set region ${var.region} && aws configure set plugins.granica awscli-plugin-granica'


### PR DESCRIPTION
1. Add accept vpc peering connection permission to admin server role since we are potentially peering a src vpc
2. Install kubectx for managing multiple kube contexts on the admin server with ease