### PR TITLE
feat: aws admin server delete permissions

### DIFF
--- a/aws/admin-server/iam.tf
+++ b/aws/admin-server/iam.tf
@@ -70,6 +70,7 @@ data "aws_iam_policy_document" "deploy" {
       "ec2:GetLaunchTemplateData",
       "ec2:RunInstances",
       "eks:CreateCluster",
+      "eks:DeleteCluster",
       "eks:ListClusters",
       "kms:CreateKey",
       "kms:EnableKeyRotation",

--- a/aws/admin-server/iam.tf
+++ b/aws/admin-server/iam.tf
@@ -103,6 +103,7 @@ data "aws_iam_policy_document" "deploy" {
       "iam:DeletePolicy",
       "iam:DeleteRole",
       "iam:DetachRolePolicy",
+      "iam:DeleteOpenIDConnectProvider",
       "iam:GetInstanceProfile",
       "iam:GetOpenIDConnectProvider",
       "iam:GetPolicy",


### PR DESCRIPTION
These permissions are necessary for destroying the created resources.